### PR TITLE
Add name to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,4 +1,5 @@
 {
+    "name": "metafabinc/php-sdk",
     "description": "Complete MetaFab API references and guides can be found at: https://trymetafab.com",
     "keywords": [
         "openapitools",


### PR DESCRIPTION
The composer.json file is missing a `name` field so you are not able to install it the conventional way without running into the following error:

```
Unknown package has no name defined ({"description":"Complete MetaFab API references and guides can be found at: https:\/\/trymetafab.com","keywords":["openapitools","openapi-generator","openapi","php","sdk","rest","api"],"homepage":"https:\/\/openapi-generator.tech","license":"unlicense","authors":[{"name":"OpenAPI-Generator contributors","homepage":"https:\/\/openapi-generator.tech"}],"require":{"php":"^7.4 || ^8.0","ext-curl":"*","ext-json":"*","ext-mbstring":"*","guzzlehttp\/guzzle":"^7.3","guzzlehttp\/psr7":"^1.7 || ^2.0"},"require-dev":{"phpunit\/phpunit":"^8.0 || ^9.0","friendsofphp\/php-cs-fixer":"^3.5"},"autoload":{"psr-4":{"MetaFab\\":"lib\/"}},"autoload-dev":{"psr-4":{"MetaFab\\Test\\":"test\/"}},"time":"2023-01-03T00:51:52+00:00","support":{"source":"https:\/\/github.com\/MetaFabInc\/metafab-php\/tree\/1.4.1","issues":"https:\/\/github.com\/MetaFabInc\/metafab-php\/issues"},"version":"dev-main","version_normalized":"dev-main","default-branch":true,"name":null,"dist":{"type":"zip","url":"https:\/\/api.github.com\/repos\/MetaFabInc\/metafab-php\/zipball\/5def444aa53572a76e5ab9c9b70f42e7a430933f","reference":"5def444aa53572a76e5ab9c9b70f42e7a430933f","shasum":""},"source":{"type":"git","url":"https:\/\/github.com\/MetaFabInc\/metafab-php.git","reference":"5def444aa53572a76e5ab9c9b70f42e7a430933f"}})
``` 

Not sure what the best naming convention should be but as long as the name is included it should work.